### PR TITLE
Created .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
There's an internal file in macOS called .DS_STORE, that gets automatically added to all folders. With this, I don't have to worry about it getting uploaded to the repository.