### PR TITLE
Removed the weapons-search code

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -445,9 +445,6 @@ var profilesKey = 'darksouls3_profiles';
             searchTag: '#item_search',
             contentTag: '#item_list h4, #item_list ul'// This does not mean that we are searching inside the content of both <h4> and <ul> tags
         }), new Jets({
-            searchTag: '#weapons_search',
-            contentTag: '#weapons_list h4, #weapons_list ul'// The outcome is that all <h4> tags are hidden while searching inside <ul> tags
-        }), new Jets({
             searchTag: '#armors_search',
             contentTag: '#armors_list ul'
         })];
@@ -459,10 +456,6 @@ var profilesKey = 'darksouls3_profiles';
         $('#item_search').keyup(function() {
             $('#item_list').unhighlight();
             $('#item_list').highlight($(this).val());
-        });
-        $('#weapons_search').keyup(function() {
-            $('#weapons_list').unhighlight();
-            $('#weapons_list').highlight($(this).val());
         });
         $('#armors_search').keyup(function() {
             $('#armors_list').unhighlight();


### PR DESCRIPTION
When the search bar for the weapons tab was removed, it crashed the entire search functionality, since the code was searching for something with the ID "#weapons_search", which didn't exist. Now that is no longer the case.